### PR TITLE
Another stab at groupWithin

### DIFF
--- a/core/jvm/src/test/scala/fs2/GroupWithinSpec.scala
+++ b/core/jvm/src/test/scala/fs2/GroupWithinSpec.scala
@@ -9,7 +9,9 @@ import TestUtil._
 
 class GroupWithinSpec extends Fs2Spec {
   "groupWithin should never lose any elements" in forAll {
-    (s: PureStream[VeryShortFiniteDuration], d: ShortFiniteDuration, maxGroupSize: SmallPositive) =>
+    (s: PureStream[VeryShortFiniteDuration],
+     d: VeryShortFiniteDuration,
+     maxGroupSize: SmallPositive) =>
       val result = s.get.toVector
       val action =
         s.get
@@ -46,6 +48,12 @@ class GroupWithinSpec extends Fs2Spec {
       withClue(s"Our full result looked like: $fullResult") {
         fullResult.head.force.toList shouldBe streamAsList.toList
       }
+  }
+
+  "groupWithin should timeout with an empty chunk if the upstream stream never returns" in forAll {
+    (n: SmallPositive, d: ShortFiniteDuration) =>
+      val grouped = Stream.eval(IO.never).groupWithin(n.get, d.get).head
+      runLog(grouped).head.force.toList shouldBe List.empty
   }
 
 }

--- a/core/jvm/src/test/scala/fs2/GroupWithinSpec.scala
+++ b/core/jvm/src/test/scala/fs2/GroupWithinSpec.scala
@@ -1,0 +1,204 @@
+package fs2
+
+import scala.concurrent.duration._
+import java.util.concurrent.TimeUnit
+import cats.effect._
+import cats.data.NonEmptyList
+
+import cats.laws.discipline.arbitrary._
+import TestUtil._
+
+class GroupWithinSpec extends Fs2Spec {
+  "groupWithin should never lose any elements" in forAll {
+    (s: PureStream[VeryShortFiniteDuration], d: ShortFiniteDuration, maxGroupSize: SmallPositive) =>
+      val result = s.get.toVector
+      val action =
+        s.get
+          .covary[IO]
+          .observe1(shortDuration => IO.sleep(shortDuration.get))
+          .groupWithin(maxGroupSize.get, d.get)
+          .flatMap(s => Stream.emits(s.force.toList))
+
+      runLog(action) shouldBe (result)
+  }
+
+  "groupWithin should never have more elements than in its specified limit" in forAll {
+    (s: PureStream[VeryShortFiniteDuration], d: ShortFiniteDuration, maxGroupSize: SmallPositive) =>
+      val maxGroupSizeAsInt = maxGroupSize.get
+      val action =
+        s.get
+          .covary[IO]
+          .observe1(shortDuration => IO.sleep(shortDuration.get))
+          .groupWithin(maxGroupSizeAsInt, d.get)
+          .map(_.force.toList.size)
+
+      runLog(action).foreach(size => size shouldBe <=(maxGroupSizeAsInt))
+  }
+
+  "groupWithin should return a finite stream back in a single chunk given a group size equal to the stream size and an absurdly high duration" in forAll {
+    (streamAsList: NonEmptyList[Int]) =>
+      println(s"Our test input: $streamAsList")
+      val action =
+        Stream
+          .emits(streamAsList.toList)
+          .covary[IO]
+          .groupWithin(streamAsList.size, FiniteDuration(Long.MaxValue - 1L, TimeUnit.NANOSECONDS))
+
+      val fullResult = runLog(action)
+      withClue(s"Our full result looked like: $fullResult") {
+        fullResult.head.force.toList shouldBe streamAsList.toList
+      }
+  }
+
+}
+// "A GroupedWithin" must {
+
+//   "group elements within the duration" taggedAs TimingTest in assertAllStagesStopped {
+//     val input = Iterator.from(1)
+//     val p = TestPublisher.manualProbe[Int]()
+//     val c = TestSubscriber.manualProbe[immutable.Seq[Int]]()
+//     Source.fromPublisher(p).groupedWithin(1000, 1.second).to(Sink.fromSubscriber(c)).run()
+//     val pSub = p.expectSubscription
+//     val cSub = c.expectSubscription
+//     cSub.request(100)
+//     val demand1 = pSub.expectRequest.toInt
+//     (1 to demand1) foreach { _ ⇒ pSub.sendNext(input.next()) }
+//     val demand2 = pSub.expectRequest.toInt
+//     (1 to demand2) foreach { _ ⇒ pSub.sendNext(input.next()) }
+//     val demand3 = pSub.expectRequest.toInt
+//     c.expectNext((1 to (demand1 + demand2).toInt).toVector)
+//     (1 to demand3) foreach { _ ⇒ pSub.sendNext(input.next()) }
+//     c.expectNoMsg(300.millis)
+//     c.expectNext(((demand1 + demand2 + 1).toInt to (demand1 + demand2 + demand3).toInt).toVector)
+//     c.expectNoMsg(300.millis)
+//     pSub.expectRequest
+//     val last = input.next()
+//     pSub.sendNext(last)
+//     pSub.sendComplete()
+//     c.expectNext(List(last))
+//     c.expectComplete
+//     c.expectNoMsg(200.millis)
+//   }
+
+//   "deliver bufferd elements onComplete before the timeout" taggedAs TimingTest in {
+//     val c = TestSubscriber.manualProbe[immutable.Seq[Int]]()
+//     Source(1 to 3).groupedWithin(1000, 10.second).to(Sink.fromSubscriber(c)).run()
+//     val cSub = c.expectSubscription
+//     cSub.request(100)
+//     c.expectNext((1 to 3).toList)
+//     c.expectComplete
+//     c.expectNoMsg(200.millis)
+//   }
+
+//   "buffer groups until requested from downstream" taggedAs TimingTest in {
+//     val input = Iterator.from(1)
+//     val p = TestPublisher.manualProbe[Int]()
+//     val c = TestSubscriber.manualProbe[immutable.Seq[Int]]()
+//     Source.fromPublisher(p).groupedWithin(1000, 1.second).to(Sink.fromSubscriber(c)).run()
+//     val pSub = p.expectSubscription
+//     val cSub = c.expectSubscription
+//     cSub.request(1)
+//     val demand1 = pSub.expectRequest.toInt
+//     (1 to demand1) foreach { _ ⇒ pSub.sendNext(input.next()) }
+//     c.expectNext((1 to demand1).toVector)
+//     val demand2 = pSub.expectRequest.toInt
+//     (1 to demand2) foreach { _ ⇒ pSub.sendNext(input.next()) }
+//     c.expectNoMsg(300.millis)
+//     cSub.request(1)
+//     c.expectNext(((demand1 + 1) to (demand1 + demand2)).toVector)
+//     pSub.sendComplete()
+//     c.expectComplete
+//     c.expectNoMsg(100.millis)
+//   }
+
+//   "drop empty groups" taggedAs TimingTest in {
+//     val p = TestPublisher.manualProbe[Int]()
+//     val c = TestSubscriber.manualProbe[immutable.Seq[Int]]()
+//     Source.fromPublisher(p).groupedWithin(1000, 500.millis).to(Sink.fromSubscriber(c)).run()
+//     val pSub = p.expectSubscription
+//     val cSub = c.expectSubscription
+//     cSub.request(2)
+//     pSub.expectRequest
+//     c.expectNoMsg(600.millis)
+//     pSub.sendNext(1)
+//     pSub.sendNext(2)
+//     c.expectNext(List(1, 2))
+//     // nothing more requested
+//     c.expectNoMsg(1100.millis)
+//     cSub.request(3)
+//     c.expectNoMsg(600.millis)
+//     pSub.sendComplete()
+//     c.expectComplete
+//   }
+
+//   "not emit empty group when finished while not being pushed" taggedAs TimingTest in {
+//     val p = TestPublisher.manualProbe[Int]()
+//     val c = TestSubscriber.manualProbe[immutable.Seq[Int]]()
+//     Source.fromPublisher(p).groupedWithin(1000, 50.millis).to(Sink.fromSubscriber(c)).run()
+//     val pSub = p.expectSubscription
+//     val cSub = c.expectSubscription
+//     cSub.request(1)
+//     pSub.expectRequest
+//     pSub.sendComplete
+//     c.expectComplete
+//   }
+
+//   "reset time window when max elements reached" taggedAs TimingTest in {
+//     val upstream = TestPublisher.probe[Int]()
+//     val downstream = TestSubscriber.probe[immutable.Seq[Int]]()
+//     Source.fromPublisher(upstream).groupedWithin(3, 2.second).to(Sink.fromSubscriber(downstream)).run()
+
+//     downstream.request(2)
+//     downstream.expectNoMsg(1000.millis)
+
+//     (1 to 4).foreach(upstream.sendNext)
+//     downstream.within(1000.millis) {
+//       downstream.expectNext((1 to 3).toVector)
+//     }
+
+//     downstream.expectNoMsg(1500.millis)
+
+//     downstream.within(1000.millis) {
+//       downstream.expectNext(List(4))
+//     }
+
+//     upstream.sendComplete()
+//     downstream.expectComplete()
+//     downstream.expectNoMsg(100.millis)
+//   }
+
+//   "reset time window when exact max elements reached" taggedAs TimingTest in {
+//     val upstream = TestPublisher.probe[Int]()
+//     val downstream = TestSubscriber.probe[immutable.Seq[Int]]()
+//     Source.fromPublisher(upstream).groupedWithin(3, 1.second).to(Sink.fromSubscriber(downstream)).run()
+
+//     downstream.request(2)
+
+//     (1 to 3).foreach(upstream.sendNext)
+//     downstream.within(1000.millis) {
+//       downstream.expectNext((1 to 3).toVector)
+//     }
+
+//     upstream.sendComplete()
+//     downstream.expectComplete()
+//   }
+
+//   "group evenly" taggedAs TimingTest in {
+//     def script = Script(TestConfig.RandomTestRange map { _ ⇒ val x, y, z = random.nextInt(); Seq(x, y, z) → Seq(immutable.Seq(x, y, z)) }: _*)
+//     TestConfig.RandomTestRange foreach (_ ⇒ runScript(script, settings)(_.groupedWithin(3, 10.minutes)))
+//   }
+
+//   "group with rest" taggedAs TimingTest in {
+//     def script = Script((TestConfig.RandomTestRange.map { _ ⇒ val x, y, z = random.nextInt(); Seq(x, y, z) → Seq(immutable.Seq(x, y, z)) }
+//       :+ { val x = random.nextInt(); Seq(x) → Seq(immutable.Seq(x)) }): _*)
+//     TestConfig.RandomTestRange foreach (_ ⇒ runScript(script, settings)(_.groupedWithin(3, 10.minutes)))
+//   }
+
+//   "group with small groups with backpressure" taggedAs TimingTest in {
+//     Source(1 to 10)
+//       .groupedWithin(1, 1.day)
+//       .throttle(1, 110.millis, 0, ThrottleMode.Shaping)
+//       .runWith(Sink.seq).futureValue should ===((1 to 10).map(List(_)))
+//   }
+
+// }

--- a/core/jvm/src/test/scala/fs2/GroupWithinSpec.scala
+++ b/core/jvm/src/test/scala/fs2/GroupWithinSpec.scala
@@ -1,7 +1,6 @@
 package fs2
 
 import scala.concurrent.duration._
-import java.util.concurrent.TimeUnit
 import cats.effect._
 import cats.data.NonEmptyList
 
@@ -37,12 +36,11 @@ class GroupWithinSpec extends Fs2Spec {
 
   "groupWithin should return a finite stream back in a single chunk given a group size equal to the stream size and an absurdly high duration" in forAll {
     (streamAsList: NonEmptyList[Int]) =>
-      println(s"Our test input: $streamAsList")
       val action =
         Stream
           .emits(streamAsList.toList)
           .covary[IO]
-          .groupWithin(streamAsList.size, FiniteDuration(Long.MaxValue - 1L, TimeUnit.NANOSECONDS))
+          .groupWithin(streamAsList.size, (Long.MaxValue - 1L).nanoseconds)
 
       val fullResult = runLog(action)
       withClue(s"Our full result looked like: $fullResult") {
@@ -51,154 +49,3 @@ class GroupWithinSpec extends Fs2Spec {
   }
 
 }
-// "A GroupedWithin" must {
-
-//   "group elements within the duration" taggedAs TimingTest in assertAllStagesStopped {
-//     val input = Iterator.from(1)
-//     val p = TestPublisher.manualProbe[Int]()
-//     val c = TestSubscriber.manualProbe[immutable.Seq[Int]]()
-//     Source.fromPublisher(p).groupedWithin(1000, 1.second).to(Sink.fromSubscriber(c)).run()
-//     val pSub = p.expectSubscription
-//     val cSub = c.expectSubscription
-//     cSub.request(100)
-//     val demand1 = pSub.expectRequest.toInt
-//     (1 to demand1) foreach { _ ⇒ pSub.sendNext(input.next()) }
-//     val demand2 = pSub.expectRequest.toInt
-//     (1 to demand2) foreach { _ ⇒ pSub.sendNext(input.next()) }
-//     val demand3 = pSub.expectRequest.toInt
-//     c.expectNext((1 to (demand1 + demand2).toInt).toVector)
-//     (1 to demand3) foreach { _ ⇒ pSub.sendNext(input.next()) }
-//     c.expectNoMsg(300.millis)
-//     c.expectNext(((demand1 + demand2 + 1).toInt to (demand1 + demand2 + demand3).toInt).toVector)
-//     c.expectNoMsg(300.millis)
-//     pSub.expectRequest
-//     val last = input.next()
-//     pSub.sendNext(last)
-//     pSub.sendComplete()
-//     c.expectNext(List(last))
-//     c.expectComplete
-//     c.expectNoMsg(200.millis)
-//   }
-
-//   "deliver bufferd elements onComplete before the timeout" taggedAs TimingTest in {
-//     val c = TestSubscriber.manualProbe[immutable.Seq[Int]]()
-//     Source(1 to 3).groupedWithin(1000, 10.second).to(Sink.fromSubscriber(c)).run()
-//     val cSub = c.expectSubscription
-//     cSub.request(100)
-//     c.expectNext((1 to 3).toList)
-//     c.expectComplete
-//     c.expectNoMsg(200.millis)
-//   }
-
-//   "buffer groups until requested from downstream" taggedAs TimingTest in {
-//     val input = Iterator.from(1)
-//     val p = TestPublisher.manualProbe[Int]()
-//     val c = TestSubscriber.manualProbe[immutable.Seq[Int]]()
-//     Source.fromPublisher(p).groupedWithin(1000, 1.second).to(Sink.fromSubscriber(c)).run()
-//     val pSub = p.expectSubscription
-//     val cSub = c.expectSubscription
-//     cSub.request(1)
-//     val demand1 = pSub.expectRequest.toInt
-//     (1 to demand1) foreach { _ ⇒ pSub.sendNext(input.next()) }
-//     c.expectNext((1 to demand1).toVector)
-//     val demand2 = pSub.expectRequest.toInt
-//     (1 to demand2) foreach { _ ⇒ pSub.sendNext(input.next()) }
-//     c.expectNoMsg(300.millis)
-//     cSub.request(1)
-//     c.expectNext(((demand1 + 1) to (demand1 + demand2)).toVector)
-//     pSub.sendComplete()
-//     c.expectComplete
-//     c.expectNoMsg(100.millis)
-//   }
-
-//   "drop empty groups" taggedAs TimingTest in {
-//     val p = TestPublisher.manualProbe[Int]()
-//     val c = TestSubscriber.manualProbe[immutable.Seq[Int]]()
-//     Source.fromPublisher(p).groupedWithin(1000, 500.millis).to(Sink.fromSubscriber(c)).run()
-//     val pSub = p.expectSubscription
-//     val cSub = c.expectSubscription
-//     cSub.request(2)
-//     pSub.expectRequest
-//     c.expectNoMsg(600.millis)
-//     pSub.sendNext(1)
-//     pSub.sendNext(2)
-//     c.expectNext(List(1, 2))
-//     // nothing more requested
-//     c.expectNoMsg(1100.millis)
-//     cSub.request(3)
-//     c.expectNoMsg(600.millis)
-//     pSub.sendComplete()
-//     c.expectComplete
-//   }
-
-//   "not emit empty group when finished while not being pushed" taggedAs TimingTest in {
-//     val p = TestPublisher.manualProbe[Int]()
-//     val c = TestSubscriber.manualProbe[immutable.Seq[Int]]()
-//     Source.fromPublisher(p).groupedWithin(1000, 50.millis).to(Sink.fromSubscriber(c)).run()
-//     val pSub = p.expectSubscription
-//     val cSub = c.expectSubscription
-//     cSub.request(1)
-//     pSub.expectRequest
-//     pSub.sendComplete
-//     c.expectComplete
-//   }
-
-//   "reset time window when max elements reached" taggedAs TimingTest in {
-//     val upstream = TestPublisher.probe[Int]()
-//     val downstream = TestSubscriber.probe[immutable.Seq[Int]]()
-//     Source.fromPublisher(upstream).groupedWithin(3, 2.second).to(Sink.fromSubscriber(downstream)).run()
-
-//     downstream.request(2)
-//     downstream.expectNoMsg(1000.millis)
-
-//     (1 to 4).foreach(upstream.sendNext)
-//     downstream.within(1000.millis) {
-//       downstream.expectNext((1 to 3).toVector)
-//     }
-
-//     downstream.expectNoMsg(1500.millis)
-
-//     downstream.within(1000.millis) {
-//       downstream.expectNext(List(4))
-//     }
-
-//     upstream.sendComplete()
-//     downstream.expectComplete()
-//     downstream.expectNoMsg(100.millis)
-//   }
-
-//   "reset time window when exact max elements reached" taggedAs TimingTest in {
-//     val upstream = TestPublisher.probe[Int]()
-//     val downstream = TestSubscriber.probe[immutable.Seq[Int]]()
-//     Source.fromPublisher(upstream).groupedWithin(3, 1.second).to(Sink.fromSubscriber(downstream)).run()
-
-//     downstream.request(2)
-
-//     (1 to 3).foreach(upstream.sendNext)
-//     downstream.within(1000.millis) {
-//       downstream.expectNext((1 to 3).toVector)
-//     }
-
-//     upstream.sendComplete()
-//     downstream.expectComplete()
-//   }
-
-//   "group evenly" taggedAs TimingTest in {
-//     def script = Script(TestConfig.RandomTestRange map { _ ⇒ val x, y, z = random.nextInt(); Seq(x, y, z) → Seq(immutable.Seq(x, y, z)) }: _*)
-//     TestConfig.RandomTestRange foreach (_ ⇒ runScript(script, settings)(_.groupedWithin(3, 10.minutes)))
-//   }
-
-//   "group with rest" taggedAs TimingTest in {
-//     def script = Script((TestConfig.RandomTestRange.map { _ ⇒ val x, y, z = random.nextInt(); Seq(x, y, z) → Seq(immutable.Seq(x, y, z)) }
-//       :+ { val x = random.nextInt(); Seq(x) → Seq(immutable.Seq(x)) }): _*)
-//     TestConfig.RandomTestRange foreach (_ ⇒ runScript(script, settings)(_.groupedWithin(3, 10.minutes)))
-//   }
-
-//   "group with small groups with backpressure" taggedAs TimingTest in {
-//     Source(1 to 10)
-//       .groupedWithin(1, 1.day)
-//       .throttle(1, 110.millis, 0, ThrottleMode.Shaping)
-//       .runWith(Sink.seq).futureValue should ===((1 to 10).map(List(_)))
-//   }
-
-// }

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1943,7 +1943,7 @@ object Stream {
               }
           }
 
-        go(Catenable.empty, 0, 0).concurrently(producer)
+        startTimeout(0) ++ go(Catenable.empty, 0, 0).concurrently(producer)
       }
     }
 

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1989,8 +1989,10 @@ object Stream {
               val newTick = unsafeNewTimeoutTick
               val outputAndRestartTimeout =
                 Pull.output1(totalNewElems) >> startTimeoutPull(newTick, tickQueue)
-              val continueAccumulating = go(totalNewElems, currentTimeout, restOfStream, tickQueue)
-              val restartGo = go(Vector.empty, newTick, restOfStream, tickQueue)
+              val continueAccumulating =
+                Pull.suspend(go(totalNewElems, currentTimeout, restOfStream, tickQueue))
+              val restartGo =
+                Pull.suspend(go(Vector.empty, newTick, restOfStream, tickQueue))
               timeoutOpt match {
                 case Some(timedout) if timedout == currentTimeout =>
                   outputAndRestartTimeout >> restartGo

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1939,7 +1939,7 @@ object Stream {
                 case Right(a) if elems >= n =>
                   emitNonEmpty(acc) ++ startTimeout(currentTimeout + 1) ++ go(
                     Catenable.singleton(Segment.singleton(a)),
-                    0,
+                    1,
                     currentTimeout + 1)
                 case Right(a) if elems < n =>
                   go(acc.snoc(Segment.singleton(a)), elems + 1, currentTimeout)

--- a/core/shared/src/test/scala/fs2/TestUtil.scala
+++ b/core/shared/src/test/scala/fs2/TestUtil.scala
@@ -53,14 +53,14 @@ object TestUtil extends TestUtilPlatform {
 
   case class ShortFiniteDuration(get: FiniteDuration)
   implicit def arbShortFiniteDuration = Arbitrary{
-    Gen.choose(1L, 50000L)
+    Gen.choose(1L, 10000L)
       .map(_.microseconds)
       .map(ShortFiniteDuration(_))
   }
 
   case class VeryShortFiniteDuration(get: FiniteDuration)
   implicit def arbVeryShortFiniteDuration = Arbitrary{
-    Gen.choose(1L, 500L)
+    Gen.choose(1L, 1000L)
       .map(_.microseconds)
       .map(VeryShortFiniteDuration(_))
   }

--- a/core/shared/src/test/scala/fs2/TestUtil.scala
+++ b/core/shared/src/test/scala/fs2/TestUtil.scala
@@ -1,10 +1,11 @@
 package fs2
 
-import java.util.concurrent.{TimeUnit, TimeoutException}
+import java.util.concurrent.TimeoutException
 
 import org.scalacheck.{Arbitrary, Cogen, Gen, Shrink}
 
 import scala.concurrent.Future
+import scala.concurrent.duration._
 import cats.effect.IO
 import cats.implicits._
 import fs2.internal.NonFatal
@@ -53,14 +54,14 @@ object TestUtil extends TestUtilPlatform {
   case class ShortFiniteDuration(get: FiniteDuration)
   implicit def arbShortFiniteDuration = Arbitrary{
     Gen.choose(1L, 50000L)
-      .map(FiniteDuration(_, TimeUnit.MICROSECONDS))
+      .map(_.microseconds)
       .map(ShortFiniteDuration(_))
   }
 
   case class VeryShortFiniteDuration(get: FiniteDuration)
   implicit def arbVeryShortFiniteDuration = Arbitrary{
     Gen.choose(1L, 500L)
-      .map(FiniteDuration(_, TimeUnit.MICROSECONDS))
+      .map(_.microseconds)
       .map(VeryShortFiniteDuration(_))
   }
 
@@ -85,7 +86,7 @@ object TestUtil extends TestUtilPlatform {
     }
     def randomlyChunked[A:Arbitrary]: Gen[PureStream[A]] = Gen.sized { size =>
       nestedVectorGen[A](0, size, true).map { chunks =>
-        PureStream(s"randomly-chunked: $size ${chunks.map(_.size)}", Stream.emits(chunks).flatMap(Stream.emits))
+        PureStream(s"randomly-chunked: $chunks $size ${chunks.map(_.size)}", Stream.emits(chunks).flatMap(Stream.emits))
       }
     }
     def uniformlyChunked[A:Arbitrary]: Gen[PureStream[A]] = Gen.sized { size =>

--- a/core/shared/src/test/scala/fs2/TestUtil.scala
+++ b/core/shared/src/test/scala/fs2/TestUtil.scala
@@ -1,13 +1,15 @@
 package fs2
 
-import java.util.concurrent.TimeoutException
+import java.util.concurrent.{TimeUnit, TimeoutException}
+
 import org.scalacheck.{Arbitrary, Cogen, Gen, Shrink}
 
 import scala.concurrent.Future
-
 import cats.effect.IO
 import cats.implicits._
 import fs2.internal.NonFatal
+
+import scala.concurrent.duration.FiniteDuration
 
 object TestUtil extends TestUtilPlatform {
 
@@ -47,6 +49,20 @@ object TestUtil extends TestUtilPlatform {
 
   case class SmallNonnegative(get: Int)
   implicit def arbSmallNonnegative = Arbitrary(Gen.choose(0,20).map(SmallNonnegative(_)))
+
+  case class ShortFiniteDuration(get: FiniteDuration)
+  implicit def arbShortFiniteDuration = Arbitrary{
+    Gen.choose(1L, 50000L)
+      .map(FiniteDuration(_, TimeUnit.MICROSECONDS))
+      .map(ShortFiniteDuration(_))
+  }
+
+  case class VeryShortFiniteDuration(get: FiniteDuration)
+  implicit def arbVeryShortFiniteDuration = Arbitrary{
+    Gen.choose(1L, 500L)
+      .map(FiniteDuration(_, TimeUnit.MICROSECONDS))
+      .map(VeryShortFiniteDuration(_))
+  }
 
   object PureStream {
     def singleChunk[A](implicit A: Arbitrary[A]): Gen[PureStream[A]] = Gen.sized { size =>


### PR DESCRIPTION
This take tries to add several new features:

+ Better handling of segments, not breaking them up when not necessary
+ More accurate buffering: we only ever buffer up to the specified n
  elements instead of potentially 2n elements
+ No integer overflow to deal with by using arbitrary java Objects for
  comparison instead of Ints